### PR TITLE
Fix the faiss-gpu problem

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ six
 scipy
 opencv-python
 matplotlib
-faiss-gpu
+faiss-gpu==1.6.3
 easydict
 pyyaml
 requests


### PR DESCRIPTION
I have tested it on different CUDA versions (9.2 & 10.2), this error should have nothing to do with the CUDA version. Download faiss-gpu through the following command: pip install faiss-gpu==1.6.3.

Machine version:
1) CUDA=10.2, python=3.6, pytorch=1.6, torchvision=0.7.0, faiss-gpu=1.6.3.
2) CUDA=9.2, python=3.6, pytorch=1.6, torchvision=0.7.0, faiss-gpu=1.6.3

If you use faiss-gpu==1.6.5, the following issue will occur: [https://github.com/yxgeee/SpCL/issues/22](https://github.com/yxgeee/SpCL/issues/22)